### PR TITLE
Remove obsolete platform config

### DIFF
--- a/bin/call_clips.py
+++ b/bin/call_clips.py
@@ -15,9 +15,7 @@ sys.path.append(lib_path)
 
 from utilities3 import (
     should_perform_task,
-    get_existing_task_output,
-    load_config,
-    set_imagemagick_env
+    get_existing_task_output
 )
 
 from utilities2 import (
@@ -49,8 +47,6 @@ clips_file = sys.argv[2]
 # Init & Config
 # ======================================
 logger = initialize_logging()
-platform_config = load_config()
-set_imagemagick_env(platform_config)
 app_config = load_app_config()
 
 

--- a/bin/call_download.py
+++ b/bin/call_download.py
@@ -3,7 +3,6 @@ import os
 import json
 import logging
 import traceback
-import platform
 from datetime import datetime
 
 # Add lib path to sys.path
@@ -14,8 +13,7 @@ sys.path.append(lib_path)
 # Import modules
 import downloader5
 import utilities1
-from utilities2 import initialize_logging, load_config
-from utilities3 import set_imagemagick_env, transcribe_full_video, extract_full_audio
+from utilities2 import initialize_logging, load_app_config
 from utilities4 import should_perform_task, get_existing_task_output, extend_metadata_with_task_output, find_url_json, copy_metadata_to_backup, load_default_tasks, add_default_tasks_to_metadata, update_task_output_path
 
 # ======================================
@@ -29,15 +27,14 @@ task = "perform_download"
 # Initialize logging once
 logger = initialize_logging()
 
-# Load platform config and set up environment
-platform_config = load_config()
-set_imagemagick_env(platform_config)
+# Load application config
+app_config = load_app_config()
 
 # Load task list from JSON config instead of YAML
 logger.info("🔴 Entering main routine... 🚀")
 default_tasks = load_default_tasks()  # Load the default task flags
 logger.info(f"🧩 Loaded default_tasks from JSON: {default_tasks}")  # Log the loaded task flags
-app_config = {"default_tasks": default_tasks}
+app_config["default_tasks"] = default_tasks
 
 # ======================================
 # Task Skipping Logic
@@ -67,7 +64,7 @@ def main():
         logger.info("🔴 Entering main download logic... 🚀")
 
         # Set up paths
-        target_usb = platform_config["target_usb"]
+        target_usb = app_config["target_usb"]
         download_date = datetime.now().strftime("%Y-%m-%d")
         download_path = os.path.join(target_usb, download_date)
 
@@ -110,9 +107,9 @@ def main():
         # Prepare parameters for function calls
         params = {
             "download_path": download_path,
-            "cookie_path": platform_config.get("cookie_path"),
+            "cookie_path": app_config.get("cookie_path"),
             "url": url,
-            **platform_config.get("watermark_config", {}),
+            **app_config.get("watermark_config", {}),
         }
 
         params["task"] = task  # ✅ add this

--- a/bin/dispatch.py
+++ b/bin/dispatch.py
@@ -12,7 +12,7 @@ lib_path = os.path.join(current_dir, "../lib/python_utils")
 sys.path.append(lib_path)
 
 # Import utilities
-from utilities2 import initialize_logging, load_config, load_app_config
+from utilities2 import initialize_logging, load_app_config
 from utilities3 import find_url_json
 
 # Map tasks to their respective scripts
@@ -81,8 +81,7 @@ def main():
 
         url = url_args[0].strip()
 
-        # Load configuration and logger
-        config = load_config()
+        # Initialize logger and load application config
         logger = initialize_logging()
         app_config = load_app_config()
         logger.info("🔁 Task Router Started")

--- a/conf/app_config.json
+++ b/conf/app_config.json
@@ -1,0 +1,5 @@
+{
+    "target_usb": "./usb_drive",
+    "cookie_path": "cookies.txt",
+    "watermark_config": {}
+}

--- a/lib/python_utils/utilities1.py
+++ b/lib/python_utils/utilities1.py
@@ -188,21 +188,15 @@ def create_subdir(base_dir="clips", subdir_name="orange"):
 
 # Load Platform-Specific Configuration
 def load_config():
-    """Load configuration based on the operating system."""
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    config_path = os.path.join(current_dir, "../conf/config.json")
+    """Return application config.
 
-    if not os.path.exists(config_path):
-        raise FileNotFoundError(f"Configuration file not found at {config_path}")
+    The old implementation loaded platform specific settings from
+    ``conf/config.json``.  That file is no longer used.  To keep the
+    existing callers working, this function simply proxies to
+    :func:`load_app_config` which reads ``conf/app_config.json``.
+    """
 
-    with open(config_path, "r") as file:
-        config = json.load(file)
-
-    os_name = platform.system()
-    if os_name not in config:
-        raise ValueError(f"Unsupported platform: {os_name}")
-
-    return config[os_name]
+    return load_app_config()
 
 
 def create_output_directory(base_dir="clips"):

--- a/lib/python_utils/video_utils.py
+++ b/lib/python_utils/video_utils.py
@@ -338,21 +338,15 @@ def create_subdir(base_dir="clips", subdir_name="orange"):
 
 # Load Platform-Specific Configuration
 def load_config():
-    """Load configuration based on the operating system."""
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    config_path = os.path.join(current_dir, "../../conf/config.json")
+    """Return application config.
 
-    if not os.path.exists(config_path):
-        raise FileNotFoundError(f"Configuration file not found at {config_path}")
+    Historically this function provided platform specific values from
+    ``conf/config.json``.  That file has been removed in favor of a
+    simpler ``conf/app_config.json``.  To maintain backward
+    compatibility, ``load_config`` now just returns the app config.
+    """
 
-    with open(config_path, "r") as file:
-        config = json.load(file)
-
-    os_name = platform.system()
-    if os_name not in config:
-        raise ValueError(f"Unsupported platform: {os_name}")
-
-    return config[os_name]
+    return load_app_config()
 
 def process_clips_with_captions(config, clips, logger, input_video, output_dir):
     """


### PR DESCRIPTION
## Summary
- drop usage of deprecated `conf/config.json`
- load settings from new `conf/app_config.json`
- update call_download, call_clips and dispatch scripts
- provide compatibility wrappers for `load_config`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c69cfd1b4832bb260b2dc91faf6c2