### PR TITLE
Fix missing traceback import

### DIFF
--- a/lib/python_utils/tasks_lib.py
+++ b/lib/python_utils/tasks_lib.py
@@ -48,6 +48,7 @@ import os
 import json
 import logging
 import shutil
+import traceback
 from typing import Optional
 
 


### PR DESCRIPTION
## Summary
- add missing `traceback` import for error logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7d87fbf8832bb2101f17d3b6aea9