### PR TITLE
Fix duplicate import in continue_tasks

### DIFF
--- a/bin/continue_tasks.py
+++ b/bin/continue_tasks.py
@@ -17,7 +17,6 @@ from tasks_lib import get_task_states, find_url_json
 logger = initialize_logging()
 
 # === MAIN EXECUTION ===
-from tasks_lib import find_url_json, get_task_states
 
 def main():
     try:


### PR DESCRIPTION
## Summary
- remove a duplicate `tasks_lib` import in `continue_tasks.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c7dabc464832b9f3d8f58c074fa67