### PR TITLE
Implement watermark stub and download/wmk test

### DIFF
--- a/lib/python_utils/watermarker2.py
+++ b/lib/python_utils/watermarker2.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+from pathlib import Path
+import logging
+
+def add_watermark(params: dict) -> dict:
+    """A lightweight stand-in for video watermarking.
+
+    This helper avoids heavy video processing dependencies. It simply
+    copies the input video to a new file with a ``_wm`` suffix and
+    returns the path to that new file.
+
+    Parameters expected in ``params``:
+        - ``input_video_path`` (str): path to the source video file.
+        - ``download_path`` (str, optional): directory for the output file.
+
+    Returns:
+        dict: ``{"to_process": <output_path>}`` when successful.
+    """
+    logger = logging.getLogger(__name__)
+
+    input_video = params.get("input_video_path")
+    if not input_video or not os.path.isfile(input_video):
+        logger.error("Input video missing for watermarking")
+        return {"to_process": None}
+
+    output_dir = params.get("download_path") or os.path.dirname(input_video)
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    stem = Path(input_video).stem
+    output_path = os.path.join(output_dir, f"{stem}_wm.mp4")
+
+    try:
+        shutil.copy(input_video, output_path)
+        logger.info(f"Watermarked video created: {output_path}")
+        return {"to_process": output_path}
+    except Exception as exc:
+        logger.error(f"Failed to create watermarked copy: {exc}")
+        return {"to_process": None}

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+import types
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "lib" / "python_utils"))
+
+# Provide a stub yt_dlp so downloader5 can be imported without the real package
+class _FakeYDL:
+    def __init__(self, *a, **k):
+        pass
+    def download(self, urls):
+        pass
+
+sys.modules['yt_dlp'] = types.SimpleNamespace(YoutubeDL=_FakeYDL)
+sys.modules['requests'] = types.SimpleNamespace()
+
+import downloader5
+import watermarker2
+
+
+def test_download_and_watermark(tmp_path, monkeypatch):
+    """Exercise downloader and watermark helpers with stubs."""
+
+    # --- stub yt_dlp so no network access is needed ---
+    class FakeYDL:
+        def __init__(self, opts):
+            self.opts = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def download(self, urls):
+            out = self.opts.get("outtmpl")
+            Path(out).write_text("dummy video")
+
+    monkeypatch.setattr(downloader5, "yt_dlp", types.SimpleNamespace(YoutubeDL=FakeYDL))
+
+    target = tmp_path / "video.mp4"
+    params = {
+        "url": "https://example.com/video",
+        "original_filename": str(target),
+        "video_download": {},
+    }
+    result = downloader5.download_video(params)
+    assert result["to_process"] == str(target)
+    assert target.exists()
+
+    wm_params = {"input_video_path": result["to_process"], "download_path": tmp_path}
+    wm_result = watermarker2.add_watermark(wm_params)
+    wm_path = Path(wm_result["to_process"])
+    assert wm_path.exists()


### PR DESCRIPTION
## Summary
- add lightweight `watermarker2.add_watermark` helper
- add a new test covering downloader and watermark integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb9d17e90832b983f05de03ed352c