### PR TITLE
Add Facebook URL sanitizer and USB config check

### DIFF
--- a/bin/call_download.py
+++ b/bin/call_download.py
@@ -13,6 +13,7 @@ sys.path.append(lib_path)
 # Import modules
 import downloader5
 from video_utils import initialize_logging, load_app_config
+from url_utils import sanitize_facebook_url
 from tasks_lib import store_params_as_json
 from tasks_lib import (
     should_perform_task,
@@ -38,6 +39,9 @@ logger = initialize_logging()
 
 # Load application config
 app_config = load_app_config()
+if "target_usb" not in app_config:
+    logger.error("target_usb not configured. Set TARGET_USB or edit conf/config.json")
+    sys.exit(1)
 
 # Load task list from JSON config instead of YAML
 logger.info("🔴 Entering main routine... 🚀")
@@ -102,6 +106,7 @@ def main():
             sys.exit(1)
 
         url = sys.argv[1].strip()
+        url = sanitize_facebook_url(url)
 
         # Attempt to find metadata for the URL
         found_file, found_data = find_url_json(url, metadata_dir="./metadata")

--- a/lib/python_utils/__init__.py
+++ b/lib/python_utils/__init__.py
@@ -6,3 +6,5 @@ from .video_utils import *           # logging, video functions
 from .watermarker2 import *          # watermarking logic
 from .whisper_utils import *         # Whisper-related functions
 
+
+from .url_utils import *         # URL helpers

--- a/lib/python_utils/url_utils.py
+++ b/lib/python_utils/url_utils.py
@@ -1,0 +1,22 @@
+import re
+from urllib.parse import urlparse, parse_qs
+
+
+def sanitize_facebook_url(url: str) -> str:
+    """Return a simplified Facebook video URL if possible."""
+    parsed = urlparse(url)
+
+    # Query parameter based share URLs
+    qs = parse_qs(parsed.query)
+    vid = None
+    if "v" in qs and qs["v"]:
+        vid = qs["v"][0]
+    else:
+        m = re.search(r"/v/([0-9A-Za-z]+)", parsed.path)
+        if m:
+            vid = m.group(1)
+
+    if not vid:
+        return url
+
+    return f"https://www.facebook.com/watch/?v={vid}"

--- a/lib/python_utils/video_utils.py
+++ b/lib/python_utils/video_utils.py
@@ -132,6 +132,16 @@ def load_app_config():
                 "Unable to load platform overrides from config.json"
             )
 
+    # Ensure the target USB location is defined
+    if "target_usb" not in app_config:
+        env_usb = os.environ.get("TARGET_USB")
+        if env_usb:
+            app_config["target_usb"] = env_usb
+        else:
+            raise RuntimeError(
+                "'target_usb' not configured. Set it in conf/config.json or via TARGET_USB environment variable."
+            )
+
     return app_config
 
 

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "lib" / "python_utils"))
+
+from url_utils import sanitize_facebook_url
+
+
+def test_sanitize_facebook_url():
+    messy = "https://www.facebook.com/share/v/12345/?mibextid=abc&__tn__=R"
+    assert sanitize_facebook_url(messy) == "https://www.facebook.com/watch/?v=12345"
+
+    simple = "https://www.facebook.com/watch/?v=6789"
+    assert sanitize_facebook_url(simple) == simple
+


### PR DESCRIPTION
## Summary
- provide `sanitize_facebook_url` helper
- expose helper via `lib/python_utils/__init__.py`
- verify `target_usb` in configuration
- use sanitized URL and check for `target_usb` in `call_download.py`
- add tests for URL sanitization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc7ac48f4832b9177cc98484adb35