### PR TITLE
Add URL host detection utility

### DIFF
--- a/bin/call_download.py
+++ b/bin/call_download.py
@@ -13,7 +13,7 @@ sys.path.append(lib_path)
 # Import modules
 import downloader5
 from video_utils import initialize_logging, load_app_config
-from url_utils import sanitize_facebook_url
+from url_utils import sanitize_facebook_url, detect_host
 from tasks_lib import store_params_as_json
 from tasks_lib import (
     should_perform_task,
@@ -107,6 +107,8 @@ def main():
 
         url = sys.argv[1].strip()
         url = sanitize_facebook_url(url)
+        host = detect_host(url)
+        logger.info(f"Detected host: {host}")
 
         # Attempt to find metadata for the URL
         found_file, found_data = find_url_json(url, metadata_dir="./metadata")
@@ -123,6 +125,7 @@ def main():
             "download_path": download_path,
             "cookie_path": app_config.get("cookie_path"),
             "url": url,
+            "host": host,
             **app_config.get("watermark_config", {}),
         }
 

--- a/lib/python_utils/url_utils.py
+++ b/lib/python_utils/url_utils.py
@@ -20,3 +20,17 @@ def sanitize_facebook_url(url: str) -> str:
         return url
 
     return f"https://www.facebook.com/watch/?v={vid}"
+
+
+def detect_host(url: str) -> str:
+    """Return a short name describing the hosting platform for ``url``."""
+    host = urlparse(url).netloc.lower()
+    if "facebook.com" in host:
+        return "facebook"
+    elif "instagram.com" in host:
+        return "instagram"
+    elif "youtube.com" in host or "youtu.be" in host:
+        return "youtube"
+    elif "google.com" in host or "googleusercontent.com" in host:
+        return "google_drive"
+    return "unknown"

--- a/tests/test_url_utils.py
+++ b/tests/test_url_utils.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "lib" / "python_utils"))
 
-from url_utils import sanitize_facebook_url
+from url_utils import sanitize_facebook_url, detect_host
 
 
 def test_sanitize_facebook_url():
@@ -12,4 +12,12 @@ def test_sanitize_facebook_url():
 
     simple = "https://www.facebook.com/watch/?v=6789"
     assert sanitize_facebook_url(simple) == simple
+
+
+def test_detect_host():
+    assert detect_host("https://www.facebook.com/watch?v=123") == "facebook"
+    assert detect_host("https://www.instagram.com/reel/abc") == "instagram"
+    assert detect_host("https://youtu.be/xyz") == "youtube"
+    assert detect_host("https://drive.google.com/file/d/123") == "google_drive"
+    assert detect_host("https://example.com") == "unknown"
 


### PR DESCRIPTION
## Summary
- add `detect_host` helper in `url_utils`
- log and store host in download params
- test host detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dca9663c8832bbbdf480cadb015d1