### PR TITLE
Add USB mount path to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Application defaults live in `conf/app_config.json`.  At runtime
 `load_app_config()` also looks for optional per-OS overrides in
 `conf/config.json` keyed by the value of `platform.system()`.  When
 present, those settings are merged into the base configuration.
+The base config now includes a `target_usb` path which download
+scripts use as the default mount point for removable storage.
 
 ## Requirements
 

--- a/conf/app_config.json
+++ b/conf/app_config.json
@@ -6,6 +6,7 @@
         "cookie_path": "./app/data/cookies.txt"
     },
     "metadata_dir": "./metadata/fb_tb",
+    "target_usb": "/Volumes/BallardT1",
     "test_url": "https://www.facebook.com/share/v/19G7Jx2x2n/?mibextid=wwXIfr&__cft__[0]=AZWs3WaCFeC33JnjAcnjMQY3QtjFqvbJRzFTrsf8f5rSrAaIJD_vGKwFjnV9z_bDTGhR9vOJo1-e_7dveL6RpZHG2qRLXLxnDAEccB6cF5cOQWj1r6gVfZNbwKi0sffOUKc&__tn__=R]-R",
     "watermark_config": {
         "font": "Arial Bold",


### PR DESCRIPTION
## Summary
- specify `target_usb` default path in app_config.json
- document the new config key in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e4687b280832b9de9b7b3ecdc9250