### PR TITLE
Add Google Drive tar download utilities

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -6,4 +6,5 @@ from .video_utils import *           # logging, video functions
 from .watermarker2 import *          # watermarking logic
 from .whisper_utils import *         # Whisper-related functions
 from .url_utils import *             # URL helpers
+from .archive_utils import *         # archive download utilities
 

--- a/lib/archive_utils.py
+++ b/lib/archive_utils.py
@@ -1,0 +1,64 @@
+import logging
+import os
+import tarfile
+import re
+import requests
+from url_utils import detect_host
+
+logger = logging.getLogger(__name__)
+
+_GDRIVE_RE = re.compile(r"(?:/file/d/|id=)([\w-]{10,})")
+
+
+def _extract_gdrive_id(url: str) -> str | None:
+    """Extract file ID from various Google Drive URL patterns."""
+    m = _GDRIVE_RE.search(url)
+    return m.group(1) if m else None
+
+
+def download_gdrive_file(url: str, dest_path: str) -> str:
+    """Download a file from Google Drive to ``dest_path``."""
+    file_id = _extract_gdrive_id(url)
+    if not file_id:
+        raise ValueError(f"Could not parse Google Drive ID from {url}")
+    dl_url = f"https://drive.google.com/uc?export=download&id={file_id}"
+    logger.info("Downloading from %s", dl_url)
+    resp = requests.get(dl_url, stream=True)
+    if resp.status_code != 200:
+        raise RuntimeError(f"Download failed with status {resp.status_code}")
+    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    with open(dest_path, "wb") as fh:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                fh.write(chunk)
+    logger.info("Saved %s", dest_path)
+    return dest_path
+
+
+def untar_archive(tar_path: str, extract_dir: str) -> list[str]:
+    """Extract ``tar_path`` into ``extract_dir`` and return list of files."""
+    logger.info("Extracting %s to %s", tar_path, extract_dir)
+    os.makedirs(extract_dir, exist_ok=True)
+    files = []
+    with tarfile.open(tar_path, "r:*") as tf:
+        tf.extractall(path=extract_dir)
+        files = [os.path.join(extract_dir, m.name) for m in tf.getmembers() if m.isfile()]
+    logger.info("Extracted %d files", len(files))
+    return files
+
+
+def handle_gdrive_tar(params: dict) -> dict:
+    """Download a Google Drive tar archive and extract it."""
+    url = params.get("url")
+    download_path = params.get("download_path", ".")
+    tar_dest = os.path.join(download_path, "archive.tar")
+    extracted_dir = os.path.join(download_path, "extracted")
+
+    host = detect_host(url)
+    if host != "google_drive":
+        raise ValueError("URL is not recognized as Google Drive")
+
+    downloaded = download_gdrive_file(url, tar_dest)
+    files = untar_archive(downloaded, extracted_dir)
+
+    return {"archive_path": downloaded, "extracted": files}

--- a/tests/inputs/gdrive_tar_task.json
+++ b/tests/inputs/gdrive_tar_task.json
@@ -1,0 +1,9 @@
+[
+  {
+    "url": "https://drive.google.com/file/d/1-POht303zzZVyMmSlejvH0LPBjCuTd03/view?usp=drive_link",
+    "tasks": {
+      "download_tar": true,
+      "untar_archive": true
+    }
+  }
+]

--- a/tests/test_gdrive_tar.py
+++ b/tests/test_gdrive_tar.py
@@ -1,0 +1,66 @@
+import io
+import tarfile
+from pathlib import Path
+import logging
+import pytest
+import types
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / "lib"))
+sys.modules.setdefault("requests", types.SimpleNamespace())
+
+import archive_utils
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+GDRIVE_URL = "https://drive.google.com/file/d/1-POht303zzZVyMmSlejvH0LPBjCuTd03/view?usp=drive_link"
+
+
+def _make_tar_bytes():
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        info = tarfile.TarInfo(name="hello.txt")
+        data = b"hello world"
+        info.size = len(data)
+        tf.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_download_and_extract_success(tmp_path, monkeypatch):
+    tar_bytes = _make_tar_bytes()
+
+    class FakeResp:
+        status_code = 200
+        def iter_content(self, chunk_size=8192):
+            yield tar_bytes
+
+    def fake_get(url, stream=True):
+        return FakeResp()
+
+    monkeypatch.setattr(archive_utils, "requests", types.SimpleNamespace(get=fake_get))
+
+    params = {"url": GDRIVE_URL, "download_path": str(tmp_path)}
+    result = archive_utils.handle_gdrive_tar(params)
+    saved = Path(result["archive_path"])
+    assert saved.exists()
+    extracted = result["extracted"]
+    assert len(extracted) == 1
+    assert Path(extracted[0]).read_text() == "hello world"
+
+
+def test_download_failure(tmp_path, monkeypatch):
+    class BadResp:
+        status_code = 404
+        def iter_content(self, chunk_size=8192):
+            return []
+    monkeypatch.setattr(
+        archive_utils,
+        "requests",
+        types.SimpleNamespace(get=lambda url, stream=True: BadResp()),
+    )
+
+    params = {"url": GDRIVE_URL, "download_path": str(tmp_path)}
+    with pytest.raises(RuntimeError):
+        archive_utils.handle_gdrive_tar(params)


### PR DESCRIPTION
## Summary
- add `archive_utils` helper for downloading from Google Drive and extracting tars
- expose `archive_utils` in package `__init__`
- include example task input file for a tar download
- test Google Drive tar download and extraction logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2648bdb8832b8bac1c8ae1260191