### PR TITLE
Add persistent output in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ venv.bak/
 
 # Test output
 *.log
+test_logs/
+test_outputs/
 
 # Python egg files
 *.egg

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -6,7 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "lib"))
 from mimesis.article import extract_article_text
 
 
-def test_extract_article_text(tmp_path):
+def test_extract_article_text():
     html_content = """
     <html><body>
         <p>First paragraph.</p>
@@ -14,9 +14,12 @@ def test_extract_article_text(tmp_path):
         <p>Second paragraph.</p>
     </body></html>
     """
-    html_file = tmp_path / "test.html"
+    out_dir = Path("test_outputs")
+    out_dir.mkdir(exist_ok=True)
+    html_file = out_dir / "test.html"
     html_file.write_text(html_content, encoding="utf-8")
 
     text = extract_article_text(str(html_file))
     assert text == "First paragraph.\n\nSecond paragraph."
+    print(f"html saved to {html_file}")
 

--- a/tests/test_log_kilroy.py
+++ b/tests/test_log_kilroy.py
@@ -40,7 +40,5 @@ def test_log_kilroy():
     assert log_file.exists(), "log file not created"
     contents = log_file.read_text()
     assert "Kilroy was here" in contents
-    # Clean up
-    for f in log_dir.glob("*"):
-        f.unlink()
-    log_dir.rmdir()
+    # leave log directory intact for inspection
+    print(f"log saved to {log_file}")

--- a/tests/test_note_synth.py
+++ b/tests/test_note_synth.py
@@ -11,15 +11,20 @@ def test_note_to_frequency_a4():
     assert abs(note_to_frequency("A4") - 440.0) < 1e-6
 
 
-def test_synthesize_notes(tmp_path):
+def test_synthesize_notes():
     notes = [
         {"pitch": "A4", "duration": "quarter"},
         {"pitch": "rest", "duration": "quarter"},
         {"pitch": "A4", "duration": "quarter"},
     ]
-    output = tmp_path / "out.wav"
+    out_dir = Path("test_outputs")
+    out_dir.mkdir(exist_ok=True)
+    output = out_dir / "out.wav"
+    if output.exists():
+        output.unlink()
     synthesize_notes(notes, 120, str(output))
     assert output.exists()
     with wave.open(str(output), "r") as wf:
         frames = wf.getnframes()
         assert frames > 0
+    print(f"audio saved to {output}")


### PR DESCRIPTION
## Summary
- stop deleting log file in `test_log_kilroy`
- write note synth and article outputs to `test_outputs`
- ignore new output directories in `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898b08085c832ba11a9c0046d9a5fc